### PR TITLE
fix: change icons for logs

### DIFF
--- a/action/label-pr/dist/main.js
+++ b/action/label-pr/dist/main.js
@@ -48,10 +48,10 @@ const rules = {
 const emojis = {
     enhancement: ':rocket:',
     bug: ':bug:',
-    documentation: ':books:',
+    documentation: ':pencil:',
     internal: ':house:',
     performance: ':chart_with_upwards_trend:',
-    breaking: ':rotating_light:',
+    breaking: ':boom:',
 };
 const match = (msg) => Object.keys(rules).filter(label => !!msg.match(rules[label]));
 const extract = (commits) => {

--- a/action/label-pr/src/main.ts
+++ b/action/label-pr/src/main.ts
@@ -15,10 +15,10 @@ const rules = {
 const emojis = {
   enhancement: ':rocket:',
   bug: ':bug:',
-  documentation: ':books:',
+  documentation: ':pencil:',
   internal: ':house:',
   performance: ':chart_with_upwards_trend:',
-  breaking: ':rotating_light:',
+  breaking: ':boom:',
 }
 
 const match = (msg: string) => Object.keys(rules).filter(label => !!msg.match(rules[label]));


### PR DESCRIPTION

## :bug: bug

[#9fee6a7](https://api.github.com/repos/odinr/action-semver-release/git/commits/9fee6a785e7a62de0131703bb46317c2fa99916e) - change icons for logs



